### PR TITLE
Resize BoundingBox calculation

### DIFF
--- a/app/src/main/java/org/y20k/trackbook/core/Track.java
+++ b/app/src/main/java/org/y20k/trackbook/core/Track.java
@@ -78,6 +78,7 @@ public class Track implements TrackbookKeys, Parcelable {
             }
 
             boundingBox = BoundingBox.fromGeoPoints(geoPoints);
+            boundingBox.increaseByScale(1.05f);
         }
         return boundingBox;
     }


### PR DESCRIPTION
Not sure if I should put something like 1.05f or .95f in the scale: doc
says `Scale this bounding box by a given factor`.

Also, why 5%? Don't know, seems like a good resize. But maybe there
should be something proportional to the actual box size? Let's try with
1.05 for now.

See issue #60.