### PR TITLE
Replace 15s interval, 15m threshold with statistical formula.

### DIFF
--- a/app/src/main/java/org/y20k/trackbook/Keys.kt
+++ b/app/src/main/java/org/y20k/trackbook/Keys.kt
@@ -96,7 +96,7 @@ object Keys {
     const val ONE_HOUR_IN_MILLISECONDS: Int = 3600000
     const val EMPTY_STRING_RESOURCE: Int = 0
     const val REQUEST_CURRENT_LOCATION_INTERVAL: Long = 1000L                   // 1 second in milliseconds
-    const val ADD_WAYPOINT_TO_TRACK_INTERVAL: Long = 15000L                     // 15 seconds in milliseconds
+    const val ADD_WAYPOINT_TO_TRACK_INTERVAL: Long = 1000L                      // 1 second in milliseconds
     const val SIGNIFICANT_TIME_DIFFERENCE: Long = 120000L                       // 2 minutes in milliseconds
     const val STOP_OVER_THRESHOLD: Long = 300000L                               // 5 minutes in milliseconds
     const val IMPLAUSIBLE_TRACK_START_SPEED: Double = 250.0                     // 250 km/h

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -76,7 +76,7 @@
     <string name="pref_about_title">About</string>
     <string name="pref_app_version_summary">Version</string>
     <string name="pref_app_version_title">App Version</string>
-    <string name="pref_accuracy_threshold_summary">Discard location fixes with an accuracy larger than:</string>
+    <string name="pref_accuracy_threshold_summary">Discard location fixes with an accuracy larger than (meters):</string>
     <string name="pref_accuracy_threshold_title">Accuracy Threshold</string>
     <string name="pref_advanced_title">Advanced</string>
     <string name="pref_delete_non_starred_summary">Delete all recordings in \"Tracks\" that are not starred.</string>


### PR DESCRIPTION
Will close #96.

Yesterday I took a long walk with this changed version of Trackbook and was happy with the results. The points were recorded about twice as frequently as normal without decreasing the track quality or rest detection.

Note!! In the future, I think we should modify `isAccurateEnough` to increase the confidence that we are below the user's set threshold. Like this:

```diff
         when (location.provider) {
-            LocationManager.GPS_PROVIDER -> isAccurate = location.accuracy < locationAccuracyThreshold
+            LocationManager.GPS_PROVIDER -> isAccurate = (location.accuracy * 2) < locationAccuracyThreshold
             else -> isAccurate = location.accuracy < locationAccuracyThreshold + 10 // a bit more relaxed when location comes from network provider
         }
```

However, I did not do that in this pull request because any user who has already tuned their accuracy threshold setting will suddenly find that their tracks are recording fewer points after updating. Increasing confidence decreases tracking interval. I don't want to make that change without further careful consideration. Likewise, we can do `accuracyDelta * 2` (or even just 1.5, etc.) if we want to increase the confidence in distance deltas.

One more note: If we're going to keep the waypoint interval at 1s, perhaps we should merge that function with MapFragment.kt's `periodicLocationRequestRunnable` which also runs at 1s. At the moment, this pull request keeps them as separate timers, which is probably a bit wasteful.

Thank you @y20k and @Hob111.