### PR TITLE
Remove resume button, let the main button act as pause/resume.

### DIFF
--- a/app/src/main/java/org/y20k/trackbook/MapFragment.kt
+++ b/app/src/main/java/org/y20k/trackbook/MapFragment.kt
@@ -92,9 +92,6 @@ class MapFragment : Fragment(), YesNoDialog.YesNoDialogListener, MapOverlayHelpe
         layout.clearButton.setOnClickListener {
             trackerService.clearTrack()
         }
-        layout.resumeButton.setOnClickListener {
-            resumeTracking()
-        }
 
         return layout.rootView
     }
@@ -259,7 +256,7 @@ class MapFragment : Fragment(), YesNoDialog.YesNoDialogListener, MapOverlayHelpe
     /* Starts / pauses tracking and toggles the recording sub menu_bottom_navigation */
     private fun handleTrackingManagementMenu() {
         when (trackingState) {
-            Keys.STATE_TRACKING_STOPPED -> layout.toggleRecordingButtonSubMenu()
+            Keys.STATE_TRACKING_STOPPED -> resumeTracking()
             Keys.STATE_TRACKING_ACTIVE -> trackerService.stopTracking()
             Keys.STATE_TRACKING_NOT -> startTracking()
         }

--- a/app/src/main/java/org/y20k/trackbook/ui/MapFragmentLayoutHolder.kt
+++ b/app/src/main/java/org/y20k/trackbook/ui/MapFragmentLayoutHolder.kt
@@ -68,7 +68,6 @@ data class MapFragmentLayoutHolder(private var context: Context, private var mar
     val recordingButtonSubMenu: Group
     val saveButton: FloatingActionButton
     val clearButton: FloatingActionButton
-    val resumeButton: FloatingActionButton
     var userInteraction: Boolean = false
     private var currentPositionOverlay: ItemizedIconOverlay<OverlayItem>
     private var currentTrackOverlay: SimpleFastPointOverlay?
@@ -93,7 +92,6 @@ data class MapFragmentLayoutHolder(private var context: Context, private var mar
         recordingButtonSubMenu = rootView.findViewById(R.id.fab_sub_menu)
         saveButton = rootView.findViewById(R.id.fab_sub_menu_button_save)
         clearButton = rootView.findViewById(R.id.fab_sub_menu_button_clear)
-        resumeButton = rootView.findViewById(R.id.fab_sub_menu_button_resume)
         liveStatisticsDistanceView = rootView.findViewById(R.id.live_statistics_distance)
         liveStatisticsDistanceOutlineView = rootView.findViewById(R.id.live_statistics_distance_outline)
         liveStatisticsDurationView = rootView.findViewById(R.id.live_statistics_duration)
@@ -236,7 +234,8 @@ data class MapFragmentLayoutHolder(private var context: Context, private var mar
                 recordingButtonSubMenu.isGone = true
             }
             Keys.STATE_TRACKING_STOPPED -> {
-                recordingButton.setImageResource(R.drawable.ic_save_24dp)
+                recordingButton.setImageResource(R.drawable.ic_fiber_manual_record_inactive_24dp)
+                recordingButtonSubMenu.isVisible = true
             }
         }
     }

--- a/app/src/main/res/layout/fragment_map.xml
+++ b/app/src/main/res/layout/fragment_map.xml
@@ -44,7 +44,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="bottom|end"
-            android:layout_marginEnd="4dp"
+            android:layout_marginEnd="8dp"
             android:clickable="true"
             android:focusable="true"
             android:visibility="gone"
@@ -81,10 +81,9 @@
             android:focusable="true"
             app:backgroundTint="@color/recording_button_background"
             app:fabSize="mini"
-            app:layout_constraintBottom_toTopOf="@+id/fab_sub_menu_button_resume"
-            app:layout_constraintEnd_toEndOf="@+id/fab_sub_menu_button_resume"
-            app:layout_constraintHorizontal_bias="0.0"
-            app:layout_constraintStart_toStartOf="@+id/fab_sub_menu_button_resume"
+            app:layout_constraintBottom_toTopOf="@+id/fab_main_button"
+            app:layout_constraintEnd_toEndOf="@+id/fab_main_button"
+            app:layout_constraintStart_toStartOf="@+id/fab_main_button"
             app:srcCompat="@drawable/ic_clear_24dp"
             app:tint="@color/recording_button_icon" />
 
@@ -93,6 +92,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="bottom|end"
+            android:layout_marginEnd="8dp"
             android:clickable="true"
             android:focusable="true"
             app:cardBackgroundColor="@color/fab_button_card_background"
@@ -101,7 +101,7 @@
             app:cardUseCompatPadding="true"
             app:strokeWidth="0dp"
             app:layout_constraintBottom_toBottomOf="@+id/fab_sub_menu_button_clear"
-            app:layout_constraintEnd_toEndOf="@+id/fab_sub_menu_label_save"
+            app:layout_constraintEnd_toStartOf="@+id/fab_sub_menu_button_clear"
             app:layout_constraintTop_toTopOf="@+id/fab_sub_menu_button_clear">
 
             <com.google.android.material.textview.MaterialTextView
@@ -117,28 +117,13 @@
         </com.google.android.material.card.MaterialCardView>
 
         <!-- BUTTON RESUME -->
-        <com.google.android.material.floatingactionbutton.FloatingActionButton
-            android:id="@+id/fab_sub_menu_button_resume"
-            style="@style/Widget.MaterialComponents.FloatingActionButton"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginBottom="16dp"
-            android:clickable="true"
-            android:contentDescription="@string/descr_fab_sub_menu_button_resume"
-            android:focusable="true"
-            app:backgroundTint="@color/recording_button_background"
-            app:fabSize="mini"
-            app:layout_constraintBottom_toTopOf="@+id/fab_main_button"
-            app:layout_constraintEnd_toEndOf="@+id/fab_main_button"
-            app:layout_constraintStart_toStartOf="@+id/fab_main_button"
-            app:srcCompat="@drawable/ic_fiber_manual_record_inactive_24dp"
-            app:tint="@color/recording_button_icon" />
 
         <com.google.android.material.card.MaterialCardView
             android:id="@+id/fab_sub_menu_label_resume"
             style="@style/Widget.MaterialComponents.CardView"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:layout_marginEnd="8dp"
             android:clickable="true"
             android:focusable="true"
             app:cardBackgroundColor="@color/fab_button_card_background"
@@ -146,9 +131,9 @@
             app:cardElevation="4dp"
             app:cardUseCompatPadding="true"
             app:strokeWidth="0dp"
-            app:layout_constraintBottom_toBottomOf="@+id/fab_sub_menu_button_resume"
-            app:layout_constraintEnd_toEndOf="@+id/fab_sub_menu_label_clear"
-            app:layout_constraintTop_toTopOf="@+id/fab_sub_menu_button_resume">
+            app:layout_constraintBottom_toBottomOf="@+id/fab_main_button"
+            app:layout_constraintEnd_toStartOf="@+id/fab_main_button"
+            app:layout_constraintTop_toTopOf="@+id/fab_main_button">
 
             <com.google.android.material.textview.MaterialTextView
                 android:layout_width="wrap_content"
@@ -248,7 +233,7 @@
             android:layout_width="0dp"
             android:layout_height="0dp"
             android:visibility="gone"
-            app:constraint_referenced_ids="fab_sub_menu_button_save,fab_sub_menu_label_save,fab_sub_menu_button_clear,fab_sub_menu_label_clear,fab_sub_menu_button_resume,fab_sub_menu_label_resume" />
+            app:constraint_referenced_ids="fab_sub_menu_button_save,fab_sub_menu_label_save,fab_sub_menu_button_clear,fab_sub_menu_label_clear,fab_sub_menu_label_resume" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 


### PR DESCRIPTION
If you don't like this idea, you can close this pull request!

Reduces the number of taps to save/clear. The main button becomes the resume button instead of toggling the submenu open and closed.

Before:

![20220404-160451_1067x698](https://user-images.githubusercontent.com/7299570/161647286-828cd6ec-be88-4ddb-8118-b7e676979bc9.png)

After:

![20220404-155815_715x698](https://user-images.githubusercontent.com/7299570/161646154-96d26079-038b-4c39-8f14-8633c368df40.png)
